### PR TITLE
Remove usage of gene.info from pipeline

### DIFF
--- a/idr/attributes.py
+++ b/idr/attributes.py
@@ -5,7 +5,7 @@ import pandas
 import omero.clients # NOQA
 from omero.rtypes import rlist, rstring, unwrap
 from omero.sys import ParametersI
-from externalDBs import get_ensembleid, ensembleid_to_genesymbol
+from externalDBs import get_entrezid, get_ensembleid, ensembleid_to_genesymbol
 
 from widgets import progress
 import numpy as np

--- a/idr/attributes.py
+++ b/idr/attributes.py
@@ -197,7 +197,7 @@ def get_phenotypes_for_genelist(session,
                                 go_gene_list,
                                 organism,
                                 idr_base_url="https://idr.openmicroscopy.org",
-                                entrez_flag=True):
+                                lookup_entrez=True):
 
     """
     Return a list of phenotypes (dataframe)
@@ -216,7 +216,7 @@ def get_phenotypes_for_genelist(session,
         if gene.startswith("-"):
             continue
 
-        if entrez_flag == True:
+        if lookup_entrez:
             entrezid = get_entrezid(gene)
         else:
             entrezid = '-'
@@ -243,7 +243,7 @@ def get_phenotypes_for_genelist(session,
 
         # search with entrezid if gene symbol and
         # ensembleid does not return any result
-        if entrez_flag == True:
+        if lookup_entrez:
             if len(uniquelist) == 0:
                 key = "EntrezID"
                 for gid in entrezid:

--- a/idr/attributes.py
+++ b/idr/attributes.py
@@ -196,7 +196,8 @@ def get_phenotypes_for_gene(session,
 def get_phenotypes_for_genelist(session,
                                 go_gene_list,
                                 organism,
-                                idr_base_url="https://idr.openmicroscopy.org"):
+                                idr_base_url="https://idr.openmicroscopy.org",
+                                entrez_flag=True):
 
     """
     Return a list of phenotypes (dataframe)
@@ -215,8 +216,10 @@ def get_phenotypes_for_genelist(session,
         if gene.startswith("-"):
             continue
 
-        # entrezid = get_entrezid(gene)
-        entrezid = '-'
+        if entrez_flag == True:
+            entrezid = get_entrezid(gene)
+        else:
+            entrezid = '-'
         ensembleid = get_ensembleid(gene)
 
         gid = None
@@ -240,13 +243,14 @@ def get_phenotypes_for_genelist(session,
 
         # search with entrezid if gene symbol and
         # ensembleid does not return any result
-        # if len(uniquelist) == 0:
-        #     key = "EntrezID"
-        #     for gid in entrezid:
-        #         uniquelist = get_phenotypes_for_gene(session,
-        #                                              gid)
-        #         if len(uniquelist['Name']) != 0:
-        #             break
+        if entrez_flag == True:
+            if len(uniquelist) == 0:
+                key = "EntrezID"
+                for gid in entrezid:
+                    uniquelist = get_phenotypes_for_gene(session,
+                                                         gid)
+                    if len(uniquelist['Name']) != 0:
+                        break
 
         # List of genes from string which were part of IDR
         if gid is not None:

--- a/idr/attributes.py
+++ b/idr/attributes.py
@@ -5,7 +5,7 @@ import pandas
 import omero.clients # NOQA
 from omero.rtypes import rlist, rstring, unwrap
 from omero.sys import ParametersI
-from externalDBs import get_entrezid, get_ensembleid, ensembleid_to_genesymbol
+from externalDBs import get_ensembleid, ensembleid_to_genesymbol
 
 from widgets import progress
 import numpy as np

--- a/idr/attributes.py
+++ b/idr/attributes.py
@@ -215,7 +215,8 @@ def get_phenotypes_for_genelist(session,
         if gene.startswith("-"):
             continue
 
-        entrezid = get_entrezid(gene)
+        # entrezid = get_entrezid(gene)
+        entrezid = '-'
         ensembleid = get_ensembleid(gene)
 
         gid = None
@@ -239,13 +240,13 @@ def get_phenotypes_for_genelist(session,
 
         # search with entrezid if gene symbol and
         # ensembleid does not return any result
-        if len(uniquelist) == 0:
-            key = "EntrezID"
-            for gid in entrezid:
-                uniquelist = get_phenotypes_for_gene(session,
-                                                     gid)
-                if len(uniquelist['Name']) != 0:
-                    break
+        # if len(uniquelist) == 0:
+        #     key = "EntrezID"
+        #     for gid in entrezid:
+        #         uniquelist = get_phenotypes_for_gene(session,
+        #                                              gid)
+        #         if len(uniquelist['Name']) != 0:
+        #             break
 
         # List of genes from string which were part of IDR
         if gid is not None:


### PR DESCRIPTION
Tag: EMBLPredoc2017Training

This version is specific for EMBLPredoc2017Training. Will need a copy of gene info database locally for getting entrez ids.

@jburel @joshmoore @manics 