### PR TITLE
Replace connection.json with a new ice properties cfg (IDR-0.4.6)

### DIFF
--- a/idr/connections.py
+++ b/idr/connections.py
@@ -1,9 +1,9 @@
 """
 Helper functions for accessing the IDR from within IPython notebooks.
 """
+import re
 import requests
 import os
-import sys
 
 import omero
 from omero.gateway import BlitzGateway
@@ -14,10 +14,15 @@ def _configuration_from_url(config_url):
     OMERO binary protocol doesn't support load balancing nor session pinning
     so it has to be done client-side by connecting to a random server/port
     """
+    try:
+        host = re.match('\w+://([^:/]+)', config_url).group(1)
+    except AttributeError:
+        host = config_url
+        config_url = 'https://%s/connection/omero-client.json' % host
     r = requests.get(config_url)
     r.raise_for_status()
     cfg = r.json()
-    return cfg
+    return cfg, host
 
 
 def _lookup_parameter(initial, paramname, default):
@@ -33,33 +38,36 @@ def connection(host=None, user=None, password=None, port=None):
     """
     Connect to the IDR analysis OMERO server
     Lookup of connection parameters is done in this order:
-    1. Parameters obtained from IDR_OMERO_CONFIGURATION_URL
-    2. Parameters passed as arguments to this method
-    3. Parameters obtained from IDR_{HOST,PORT,USER,PASSWORD}
 
-    There are no defaults to prevent settings in
-    IDR_OMERO_CONFIGURATION_URL from being overridden
+    1. If host/IDR_HOST starts with protocol:// treat this as a full
+       omero-client.json configuration URL and fetch it
+    2. If host/IDR_HOST is defined but port/IDR_PORT empty then attempt
+       to fetch configuration from
+       https://host/connection/omero-client.json
+    3. Remaining parameters are taken first from the method arguments,
+       then from IDR_{HOST,PORT,USER,PASSWORD}
+    4. If host/IDR_HOST was a configuration URL then automatically set
+       host to the host portion of the URL in case it needs to be
+       substituted into the fetched configuration
+
+    No defaults are provided
 
     :return: A BlitzGateway object
     """
-    autocfg = []
-    config_url = os.getenv('IDR_OMERO_CONFIGURATION_URL')
-    if config_url:
-        try:
-            autocfg = _configuration_from_url(config_url)
-        except Exception as e:
-            print >> sys.stderr, 'Failed to fetch configuration: %r' % e
-
-    host = _lookup_parameter(host, 'host', None)
-    port = _lookup_parameter(port, 'port', None)
+    host = _lookup_parameter(host, 'host', '')
+    port = int(_lookup_parameter(port, 'port', 0))
     user = _lookup_parameter(user, 'user', None)
     password = _lookup_parameter(password, 'password', None)
 
+    autocfg = []
+    if (host and not port) or re.match('\w+://', host):
+        autocfg, host = _configuration_from_url(host)
+
     # https://github.com/openmicroscopy/openmicroscopy/blob/v5.4.3/components/tools/OmeroPy/src/omero/clients.py#L50
     kwargs = {'args': autocfg}
-    if host is not None:
+    if host:
         kwargs['host'] = host
-    if port is not None:
+    if port:
         kwargs['port'] = port
 
     c = omero.client(**kwargs)

--- a/idr/connections.py
+++ b/idr/connections.py
@@ -34,7 +34,7 @@ def _lookup_parameter(initial, paramname, default):
     return default
 
 
-def connection(host=None, user=None, password=None, port=None):
+def connection(host=None, user=None, password=None, port=None, verbose=1):
     """
     Connect to the IDR analysis OMERO server
     Lookup of connection parameters is done in this order:
@@ -75,7 +75,13 @@ def connection(host=None, user=None, password=None, port=None):
     c.createSession(user, password)
     conn = BlitzGateway(client_obj=c)
 
-    print "Connected to IDR..."
+    if verbose > 0:
+        server = ''
+        if verbose > 1:
+            info = conn.c.sf.ice_getConnection().getInfo()
+            server = '[{}:{}]'.format(info.remoteAddress, info.remotePort)
+
+        print("Connected to IDR%s ..." % server)
     return conn
 
 


### PR DESCRIPTION
Breaking change.

Connect using the config file from https://github.com/IDR/deployment/pull/73

# Test scenarios

----
```
from idr import connection
c = connection('idr-testing.openmicroscopy.org',
               user=<USER>, password=<PASSWORD>, verbose=2)
c.close()
```
Output should be randomly chosen from:
- `Connected to IDR[193.62.52.70:14060] ...`
- `Connected to IDR[193.62.52.70:14061] ...`

----
```
from idr import connection
c = connection('https://idr-testing.openmicroscopy.org/connection/omero-client.json',
               user=<USER>, password=<PASSWORD>, verbose=2)
c.close()
```
Output should be randomly chosen from:
- `Connected to IDR[193.62.52.70:14060] ...`
- `Connected to IDR[193.62.52.70:14061] ...`

----
```
from idr import connection
c = connection('idr-testing.openmicroscopy.org',
               user=<USER>, password=<PASSWORD>, port=<PORT>, verbose=2)
c.close()
```
where `<PORT>` is 14060 or 14061
Expected output:
- `Connected to IDR[193.62.52.70:<PORT>] ...`
where `<PORT>` matches the port passed to `connection()`

----
```
from idr import connection
c = connection('idr-testing.openmicroscopy.org',
              user=<USER>, password=<PASSWORD>, verbose=0)
c.close()
```
Expected output: Nothing

----
```
from idr import connection
c = connection('idr-testing.openmicroscopy.org',
               user=<USER>, password=<PASSWORD>)
c.close()
```
Expected output:
- `Connected to IDR ...`

----
```
from idr import connection
c = connection(user=<USER>, password=<PASSWORD>)
```
Expected output:
- Exception traceback `ClientError: No host specified.`

----
In addition `host`, `user`, `password`, `port` can be defined as environment vars `IDR_{HOST,USER,PASSWORD,PORT}`