### PR TITLE
Add travis pypi deploy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,3 +15,10 @@ script:
  # TODO: Set IDR_USER IDR_HOST IDR_PASSWORD and run tests
  #- pytest
  - ./travis-conda-test.sh
+
+deploy:
+  provider: pypi
+  user: $PYPI_USER
+  password: $PYPI_PASSWORD
+  on:
+    tags: true


### PR DESCRIPTION
This requires:
- `$PYPI_USER`
- `$PYPI_PASSWORD`

in travis to push to https://pypi.org/project/idr-py/