### PR TITLE
add requirements.txt to MANIFEST.in

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,3 @@
+include requirements.txt
 include README.rst
 recursive-include idr *


### PR DESCRIPTION
Currently missing from packaged repo
```
$ pip install idr-py==0.4.0.dev2

Collecting idr-py==0.4.0.dev2
  Downloading https://files.pythonhosted.org/packages/62/60/96ea7c5f2ea2279c95919563429992302c616a4c88196f0186e324d94df4/idr-py-0.4.0.dev2.tar.gz
    Complete output from command python setup.py egg_info:
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/private/var/folders/z0/tv7cs0n16m54ytpp_2tsk2c9w3bcxl/T/pip-install-xhakab6m/idr-py/setup.py", line 66, in <module>
        install_requires=get_requirements(),
      File "/private/var/folders/z0/tv7cs0n16m54ytpp_2tsk2c9w3bcxl/T/pip-install-xhakab6m/idr-py/setup.py", line 40, in get_requirements
        with open(filename) as f:
    FileNotFoundError: [Errno 2] No such file or directory: 'requirements.txt'
```