### PR TITLE
idr.connection: fall back to websocket, allow user/pass

### DIFF
--- a/idr/connections.py
+++ b/idr/connections.py
@@ -79,9 +79,18 @@ def connection(host=None, user=None, password=None, port=None, verbose=1):
         kwargs['port'] = port
 
     c = omero.client(**kwargs)
-    c.enableKeepAlive(300)
+
+    # If omero.user and omero.pass were included in omero-client.json
+    # they can optionally be omitted in createSession
+    create_session_args = []
+    if user:
+        create_session_args.append(user)
+        if password:
+            create_session_args.append(password)
+
     try:
-        c.createSession(user, password)
+        c.createSession(*create_session_args)
+        c.enableKeepAlive(300)
         conn = BlitzGateway(client_obj=c)
     except omero.ClientError as e:
         if re.match(r'\w+://', host):

--- a/idr/connections.py
+++ b/idr/connections.py
@@ -57,6 +57,10 @@ def connection(host=None, user=None, password=None, port=None, verbose=1):
        host to the host portion of the URL in case it needs to be
        substituted into the fetched configuration
 
+    To support firewalled environments if host/IDR_HOST has no protocol and the
+    connection fails automatically attempt to reconnect using websockets (wss)
+    on port 443.
+
     No defaults are provided
 
     :return: A BlitzGateway object

--- a/idr/connections.py
+++ b/idr/connections.py
@@ -47,7 +47,7 @@ def connection(host=None, user=None, password=None, port=None, verbose=1):
     1. If host/IDR_HOST starts with protocol:// and protocol is not an Ice
        transport treat this as a full omero-client.json configuration URL and
        fetch it
-    2. If host/IDR_HOST starts with an ice transport:// connect directly
+    2. If host/IDR_HOST starts with an Ice transport:// connect directly
     3. If host/IDR_HOST is defined but port/IDR_PORT empty and there is no
        protocol then attempt to fetch configuration from
        https://host/connection/omero-client.json


### PR DESCRIPTION
If connecting using https://idr.openmicroscopy.org/connection/omero-client.json fails attempt to connect to `wss://idr.openmicroscopy.org/omero-ws`
Once this is released we should be able to run all IDR Python notebooks on mybinder.

Example on mybinder:
![binder-idr-wss](https://user-images.githubusercontent.com/1644105/70064894-2ffb1e00-15e2-11ea-8b38-00362ebd4856.png)

----

This also adds support for specifying the `omero.user` and `omero.pass` in `omero-client.json`.
Note this will not work with the wss fallback since in the latter case `omero-client.json` is not read. Therefore if we decide to include `omero.user` and `omero.pass` in https://idr.openmicroscopy.org/connection/omero-client.json we should also change the connection to use `websockets` (and thie fallback option in this library could be removed).

In the meantime I think this is a useful fallback until we decide to fully make the switch to websockets (which I'm in favour of, but we can't update https://idr.openmicroscopy.org/connection/omero-client.json until the VAE Docker images are updated since OMERO.py 5.4 doesn't support websockets).

To test the included user/password:
```python
from idr import connection
c = connection('https://users.openmicroscopy.org.uk/~spli/testing/omero-client.json', verbose=2)
```
(edited: using `testing` instead of `internal`)
<img width="953" alt="Screen Shot 2019-12-03 at 16 41 17" src="https://user-images.githubusercontent.com/1644105/70070597-cf70de80-15eb-11ea-8924-ede431034f38.png">
